### PR TITLE
Add Python Docstring Support

### DIFF
--- a/demo/python.py
+++ b/demo/python.py
@@ -1,6 +1,7 @@
 from collections import deque
 
 def topo(G, ind=None, Q=[1]):
+    """This is a docstring."""
     if ind == None:
         ind = [0] * (len(G) + 1) #this is a comment
         for u in G:

--- a/themes/Overnight-Slumber-italic.json
+++ b/themes/Overnight-Slumber-italic.json
@@ -1601,6 +1601,18 @@
             }
         },
         {
+            "name": "Python Docstring",
+            "scope": [
+              "string.quoted.docstring.multi",
+              "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+              "string.quoted.docstring.multi.python punctuation.definition.string.end",
+              "string.quoted.docstring.multi.python constant.character.escape"
+            ],
+            "settings": {
+              "foreground": "#637777"
+            }
+        },
+        {
             "name": "Python Function Parameter and Arguments",
             "scope": ["variable.parameter.function.python", "meta.function-call.arguments.python"],
             "settings": {

--- a/themes/Overnight-Slumber.json
+++ b/themes/Overnight-Slumber.json
@@ -1586,6 +1586,18 @@
             }
         },
         {
+            "name": "Python Docstring",
+            "scope": [
+              "string.quoted.docstring.multi",
+              "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+              "string.quoted.docstring.multi.python punctuation.definition.string.end",
+              "string.quoted.docstring.multi.python constant.character.escape"
+            ],
+            "settings": {
+              "foreground": "#637777"
+            }
+        },
+        {
             "name": "Python Function Parameter and Arguments",
             "scope": ["variable.parameter.function.python", "meta.function-call.arguments.python"],
             "settings": {

--- a/themes/Overnight-color-theme-italic.json
+++ b/themes/Overnight-color-theme-italic.json
@@ -1492,6 +1492,18 @@
             }
         },
         {
+            "name": "Python Docstring",
+            "scope": [
+              "string.quoted.docstring.multi",
+              "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+              "string.quoted.docstring.multi.python punctuation.definition.string.end",
+              "string.quoted.docstring.multi.python constant.character.escape"
+            ],
+            "settings": {
+              "foreground": "#637777"
+            }
+        },
+        {
             "name": "Python Function Parameter and Arguments",
             "scope": ["variable.parameter.function.python", "meta.function-call.arguments.python"],
             "settings": {

--- a/themes/Overnight-color-theme.json
+++ b/themes/Overnight-color-theme.json
@@ -1491,6 +1491,18 @@
             }
         },
         {
+            "name": "Python Docstring",
+            "scope": [
+              "string.quoted.docstring.multi",
+              "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+              "string.quoted.docstring.multi.python punctuation.definition.string.end",
+              "string.quoted.docstring.multi.python constant.character.escape"
+            ],
+            "settings": {
+              "foreground": "#637777"
+            }
+        },
+        {
             "name": "Python Function Parameter and Arguments",
             "scope": ["variable.parameter.function.python", "meta.function-call.arguments.python"],
             "settings": {


### PR DESCRIPTION
Greetings,

I work with Python probably the most often, and would love to have docstrings formatted similarly to comments on this theme (which is _great_, by the way). I've confirmed that these changes do just that. I've also added a docstring to the Python example.

Thanks!